### PR TITLE
fix(i18n): add header translations for processing 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,10 +47,11 @@ pull_translations:
       && atlas pull $(ATLAS_OPTIONS) \
                translations/frontend-platform/src/i18n/messages:frontend-platform \
                translations/paragon/src/i18n/messages:paragon \
+	           translations/frontend-component-header/src/i18n/messages:frontend-component-header \
                translations/frontend-component-footer/src/i18n/messages:frontend-component-footer \
                translations/frontend-app-learner-dashboard/src/i18n/messages:frontend-app-learner-dashboard
 
-	$(intl_imports) frontend-platform paragon frontend-component-footer frontend-app-learner-dashboard
+	$(intl_imports) frontend-platform paragon frontend-component-header frontend-component-footer frontend-app-learner-dashboard
 
 # This target is used by CI.
 validate-no-uncommitted-package-lock-changes:


### PR DESCRIPTION
## Context

Previously we unified MFE header for the LDMFE app.
Before that it's heading translations were maintained internally.
But now the app requires another set of external translations for header component.